### PR TITLE
Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN go get github.com/mailhog/mhsendmail \
   && cp /root/go/bin/mhsendmail /usr/bin/mhsendmail
 
 # Apache Extensions
-RUN a2enmod headers rewrite expires deflate
+RUN a2enmod headers rewrite expires deflate proxy_http
 
 
 # Entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY config/php.ini /usr/local/etc/php/
 
 # Dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    mysql-client \
+    default-mysql-client \
     libjpeg-dev \
     libpng-dev \
     libmagickwand-dev \


### PR DESCRIPTION
I tried to fix error about ProxyPassMatch
```
AH00526: Syntax error on line 24 of /etc/apache2/sites-enabled/crolla-lowis.conf:
web_1  | Invalid command 'ProxyPassMatch', perhaps misspelled or defined by a module not included in the server configuration
```
Interwebz say we should enable proxy_http module.

On this occasian I also saw that mysql-client package name has changed. 